### PR TITLE
Remove trademark conref from headers

### DIFF
--- a/machine-learning-cli.md
+++ b/machine-learning-cli.md
@@ -43,7 +43,8 @@ Example: -->
 
 <p>&nbsp;</p>
 
-In May 2018, the {{site.data.keyword.Bluemix_notm}} CLI commands changed from `bluemix` and `bx` to `ibmcloud`. So, for example, the command `bx ml help` became `ibmcloud ml help`.  You can still use the `bluemix` and `bx` CLI commands until they are removed in the future.  If you have scripts that use the `bluemix` and `bx` commands, update those scripts to use `ibmcloud` (or consider other strategies, such as using command aliases.)  {: tip}
+In May 2018, the {{site.data.keyword.Bluemix_notm}} CLI commands changed from `bluemix` and `bx` to `ibmcloud`. So, for example, the command `bx ml help` became `ibmcloud ml help`.  You can still use the `bluemix` and `bx` CLI commands until they are removed in the future.  If you have scripts that use the `bluemix` and `bx` commands, update those scripts to use `ibmcloud` (or consider other strategies, such as using command aliases.)
+{: tip}
 
 <p>&nbsp;</p>
 

--- a/machine-learning-cli.md
+++ b/machine-learning-cli.md
@@ -1,8 +1,8 @@
 ---
  
 copyright:
-  years: 2015, 2018
-lastupdated: "2018-10-04"
+  years: 2015, 2019
+lastupdated: "2019-02-28"
 
 ---
 
@@ -18,7 +18,7 @@ lastupdated: "2018-10-04"
 <!-- Name your file `offering-cli-name.md`, for example, `auto-scaling-cli.md` is the file name of the Auto-Scaling CLI reference topic. Delete content examples and coding that you are not using for your offering. -->
 
 
-# {{site.data.keyword.pm_full}} CLI
+# {{site.data.keyword.ibmwatson_notm}} {{site.data.keyword.pm_short}} CLI
 <!-- Insert your CLI name into topic title above. -->
 {: #machine-learning-cli}
 <!-- Provide an appropriate ID above -->
@@ -56,7 +56,7 @@ If there are a great many commands, to make it easy to retrieve specific command
 Examples: -->
 
 
-## {{site.data.keyword.pm_full}} CLI commands index
+## {{site.data.keyword.ibmwatson_notm}} {{site.data.keyword.pm_short}} CLI commands index
 {: #commands_index}
 
 You can specify one of the following commands:


### PR DESCRIPTION
Causing broken toc titles in nav showing.